### PR TITLE
Optimize dev Dockerfile for rebuild speed and readonly filesystem, and don't embed .npmrc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
+.env
+.git
+.gitattributes
+.gitignore
+.npmrc
 .npmrc.template
 npm-debug.log
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,21 @@ FROM node:16-bullseye-slim AS builder
 WORKDIR /home/node/app
 
 COPY . .
-RUN yarn cache clean && yarn install && yarn build
+RUN --mount=type=secret,id=npmrc,required=true,target=./.npmrc,uid=1000 \
+    yarn cache clean && yarn install && yarn build
 
 # Production stage
 FROM node:16-bullseye-slim AS production
 WORKDIR /home/node/app
 
 COPY --from=builder /home/node/app/package.json .
-COPY --from=builder /home/node/app/.npmrc .
 COPY --from=builder /home/node/app/dist ./dist
 COPY --from=builder /home/node/app/public ./public
 COPY --from=builder /home/node/app/views ./views
 
 
-RUN yarn install --production
+RUN --mount=type=secret,id=npmrc,required=true,target=./.npmrc,uid=1000 \
+    yarn install --production
 
 ENV NODE_ENV production
 EXPOSE 8003

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npx tsc",
     "dev": "nodemon --config nodemon.json --exec \"npx tsc && yarn start\"",
+    "dev-docker": "npx nodemon --config nodemon.json --exec \"npx tsc --outdir /app/dist && yarn start\"",
     "start": "node -r source-map-support/register dist/src/app.js",
     "build:prod": "rm -rf node_modules && yarn install && yarn build && rm -rf node_modules && yarn install --production",
     "snapshot": "paketo"


### PR DESCRIPTION
Companion PR of wwWallet/wallet-ecosystem#32.

This restructures the development Dockerfile to put `node_modules` in a readonly filesystem and to make maximal use of the Docker build cache. This makes the installed dependencies consistently determined by the Docker image alone, independent of any runtime state held in volumes. The optimized layer order also enables using `docker-compose up --build` in the parent project to automatically rebuild the image on any changes to dependencies.

Unlike `wallet-backend-server`, does not move `dist/` outside of the sources directory, since there are relative imports that expect `keys/`, `views/` etc. to be sibling directories of `dist/`.

Finally, this expects `.npmrc` in both prod and dev to be mounted as a [secret mount](https://docs.docker.com/engine/reference/builder/#run---mounttypesecret) only at build time, instead of embedding the GitHub token into the resulting image.