### PR TITLE
Fix Pre-Populated Username/Password

### DIFF
--- a/views/issuer/login.pug
+++ b/views/issuer/login.pug
@@ -11,7 +11,7 @@ block layout-content
 						input#csrf-token(type="hidden" name="csrf-token" value="")
 
 						.input-wrap.item
-							input.input-field#username(type='text' name='username' value="user" placeholder='Username')
+							input.input-field#username(type='text' name='username' value="user1" placeholder='Username')
 						.input-wrap.item
 							input.input-field#password(type='password' name='password' value="secret" placeholder='Password')
 


### PR DESCRIPTION
This PR addresses the issue where pre-populated username and password fields do not work, resulting in an "Invalid Credentials" error. The fix involves updating the pre-populated credentials to match the new username and password specified in our documentation.
