### PR TITLE
Update Check/Uncheck Icons on Credentials Selection for Improved Visibility

### DIFF
--- a/public/styles/consent.css
+++ b/public/styles/consent.css
@@ -142,10 +142,14 @@ section.MainLayout {
 	padding-bottom: 30px;
 }
 .is-selected, .is-not-selected {
-	margin-bottom: 15px;
-	margin-right: 15px;
 	font-size: 20px;
-	color: white;
+	color: var(--primary-color);
+	background-color: white;
+	position:absolute;
+	top:-10px;
+	right: -10px;
+	padding: 2px;
+	border-radius: 20px;
 }
 
 .GetMultiBtn {

--- a/views/issuer/consent.pug
+++ b/views/issuer/consent.pug
@@ -37,10 +37,10 @@ block layout-content
 						for credential, index in credentialViewList
 							.credential-card
 								input(type="hidden" name="selected_credential_id_list[]" id=`${credential.credential_id}_${index}` value=`${credential.credential_id}` disabled)
-								a.credential.toggle-card(id=`${credential.credential_id}_${index}` style=`background-image: url(${credential.credential_supported_object.display[0].logo.url});`)
+								a.credential.toggle-card(id=`${credential.credential_id}_${index}` style=`position:relative; background-image: url(${credential.credential_supported_object.display[0].logo.url});`)
 									if grant_type == "authorization_code"
-										i.is-selected.fa.fa-check-square-o(aria-hidden="true" style="display: none;")
-										i.is-not-selected.fa.fa-square-o(aria-hidden="true")
+										i.is-selected.fa.fa-check-circle-o(aria-hidden="true" style="display: none;")
+										i.is-not-selected.fa.fa-circle-o(aria-hidden="true")
 								a.toggle-details(id=`${credential.credential_id}_${index}` style="display:inline;")
 									span.show-text
 										| Show Details 


### PR DESCRIPTION
This PR updates the style of check/uncheck icons on the Credentials selection to enhance user-friendliness and ensure better visibility. In scenarios where a white card is used as the background, the uncheck icon was previously not visible. The updated icons, position and colors ensuring that both check and uncheck states are clearly distinguishable, regardless of the card color.