### PR TITLE
Handle non-existent display object in credential issuer metadata

### DIFF
--- a/src/verifier/verifierRouter.ts
+++ b/src/verifier/verifierRouter.ts
@@ -132,8 +132,7 @@ verifierRouter.post('/callback', async (req, res) => {
 			credentialImages.push(fistImageUri);
 		}
 		else {
-			console.error("Not supported format. Parsing failed")
-			return res.status(400).send({ error: "Not supoorted format" })	
+			credentialImages.push(config.url + "/images/card.png");
 		}
 	}
 	else {

--- a/src/verifier/verifierRouter.ts
+++ b/src/verifier/verifierRouter.ts
@@ -113,7 +113,7 @@ verifierRouter.post('/callback', async (req, res) => {
 		console.log("Credential issuer metadata = ", credentialIssuerMetadata.data)
 		const fistImageUri = Object.values(credentialIssuerMetadata.data.credential_configurations_supported).map((conf: any) => {
 			if (conf?.vct == parsedCredential?.vct) {
-				return conf?.display[0] ? conf?.display[0]?.background_image?.uri : undefined;
+				return conf?.display && conf?.display[0] && conf?.display[0]?.background_image?.uri ? conf?.display[0]?.background_image?.uri : undefined;
 			}
 			return undefined;
 		}).filter((val) => val)[0];


### PR DESCRIPTION
This PR:
- handles case where display object does not exist
- utilizes the card.png default card image for display purposes on the verifier side