### PR TITLE
Use single certificate

### DIFF
--- a/src/configuration/issuerSigner.ts
+++ b/src/configuration/issuerSigner.ts
@@ -11,11 +11,17 @@ import { importPrivateKeyPem } from '../lib/importPrivateKeyPem';
 import {  base64url, calculateJwkThumbprint, exportJWK, importX509 } from 'jose';
 import { Document } from '@auth0/mdl';
 import { cborEncode } from "@auth0/mdl/lib/cbor";
+import { pemToBase64 } from '../util/pemToBase64';
 
-const issuerX5C: string[] = JSON.parse(fs.readFileSync(path.join(__dirname, "../../../keys/x5c.json"), 'utf-8').toString()) as string[];
+const caCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/ca.crt"), 'utf-8').toString() as string;
 const issuerPrivateKeyPem = fs.readFileSync(path.join(__dirname, "../../../keys/pem.key"), 'utf-8').toString();
-const issuerCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/pem.crt"), 'utf-8').toString() as string;;
+const issuerCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/pem.crt"), 'utf-8').toString() as string;
 // const caCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/ca.crt"), 'utf-8').toString() as string;;
+
+const issuerX5C = [
+	pemToBase64(issuerCertPem),
+	pemToBase64(caCertPem)
+];
 
 importPrivateKeyPem(issuerPrivateKeyPem, 'ES256') // attempt to import the key
 importX509(issuerCertPem, 'ES256'); // attempt to import the public key

--- a/src/services/ExpressAppService.ts
+++ b/src/services/ExpressAppService.ts
@@ -11,15 +11,20 @@ import fs from 'fs';
 import path from 'path';
 import * as IssuerSigner from '../configuration/issuerSigner';
 import { credentialConfigurationRegistryServiceEmitter } from './CredentialConfigurationRegistryService';
+import { pemToBase64 } from '../util/pemToBase64';
 
 var issuerX5C: string[] = [];
 var issuerPrivateKeyPem = "";
 var issuerCertPem = "";
 var rootCaBase64DER = "";
 if (config.appType == "ISSUER") {
-	issuerX5C = JSON.parse(fs.readFileSync(path.join(__dirname, "../../../keys/x5c.json"), 'utf-8').toString()) as string[];
+	const caCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/ca.crt"), 'utf-8').toString() as string;
 	issuerPrivateKeyPem = fs.readFileSync(path.join(__dirname, "../../../keys/pem.key"), 'utf-8').toString();
 	issuerCertPem = fs.readFileSync(path.join(__dirname, "../../../keys/pem.crt"), 'utf-8').toString() as string;
+	issuerX5C = [
+		pemToBase64(issuerCertPem),
+		pemToBase64(caCertPem)
+	];
 
 	rootCaBase64DER = fs.readFileSync(path.join(__dirname, "../../../keys/ca.crt"), 'utf-8').toString() as string;
 	rootCaBase64DER = rootCaBase64DER.replace(/-----BEGIN CERTIFICATE-----/g, '')

--- a/src/util/pemToBase64.ts
+++ b/src/util/pemToBase64.ts
@@ -1,0 +1,7 @@
+export function pemToBase64(pem: string) {
+  const base64 = pem
+    .replace(/-----BEGIN CERTIFICATE-----/g, '')
+    .replace(/-----END CERTIFICATE-----/g, '')
+    .replace(/\r?\n|\r/g, '');
+  return base64;
+}


### PR DESCRIPTION
This PR has the following effects:
- use `ES256` for JAR on OpenID4VP to conform with [HAIP draft 3](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-03.html)
- use one keypair instead two

Related PRs:
- https://github.com/wwWallet/wallet-ecosystem/pull/218