### PR TITLE
Handle issuance edge cases + Credential issuance refactoring #163

### DIFF
--- a/src/services/ExpressAppService.ts
+++ b/src/services/ExpressAppService.ts
@@ -78,7 +78,7 @@ export class ExpressAppService {
 			});
 
 			app.post('/openid4vci/credential', async (req, res) => {
-				this.authorizationServerService.credentialRequestHandler({ req, res });
+				return this.authorizationServerService.credentialRequestHandler({ req, res });
 			})
 
 			// @ts-ignore


### PR DESCRIPTION
Here error management of credential issuance is improved to handle edge cases highlighted performing integration tests.

## Changes
- throw and rescue `CredentialIssuanceError` to have standard `invalid_request` responses at credential issuance
- moved attestation proof validations within `proofJwtVerification`
- moved dpop and proof validations in a try / catch block rescuing only known errors