### PR TITLE
Add Utility to Convert SD-JWT VC Metadata Claims to OpenID4VCI Credential Supported Claims

### DIFF
--- a/src/lib/convertSdjwtvcToOpenid4vciClaims.ts
+++ b/src/lib/convertSdjwtvcToOpenid4vciClaims.ts
@@ -1,0 +1,31 @@
+type MetadataClaim = {
+	path: string[];
+	display?: { lang: string; label: string }[];
+};
+
+type JsonSchema = {
+	required?: string[];
+};
+
+export function convertSdjwtvcToOpenid4vciClaims(
+	metadataClaims: MetadataClaim[],
+	schema: JsonSchema
+): any[] {
+	const requiredTopLevel = new Set(schema.required || []);
+
+	return metadataClaims.map(claim => {
+		const topKey = claim.path[0];
+		const isMandatory = requiredTopLevel.has(topKey);
+
+		const display = (claim.display || []).map(d => ({
+			locale: d.lang,
+			name: d.label
+		}));
+
+		return {
+			path: claim.path,
+			...(isMandatory ? { mandatory: true } : {mandatory: false}),
+			...(display.length > 0 ? { display } : {})
+		};
+	});
+}


### PR DESCRIPTION
This PR introduces a reusable utility function `convertSdjwtvcToOpenid4vciClaims` that transforms SD-JWT VC metadata claims and their corresponding JSON schema into a `claims` array compatible with OpenID4VCI's `Credential Supported Object`.

Related with https://github.com/wwWallet/wallet-ecosystem/pull/232 