### PR TITLE
Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  # safe auto-fixers (end-of-file newline)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+        name: Minor auto-fixes
+        exclude: ^(node_modules|dist|build|public/font-awesome)/
+
+  - repo: local
+    hooks:
+      - id: editorconfig-checker-docker
+        name: Check .editorconfig rules
+        language: docker_image
+        entry: mstruebing/editorconfig-checker:latest
+        args: ["ec", "-no-color"]
+        types_or: [text]
+        exclude: ^(node_modules|dist|build|public/font-awesome)/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+## Pre-commit
+
+We use [pre-commit](https://pre-commit.com/) to enforce our `.editorconfig` (newline at EOF, no bad indentation, etc.) before code is committed.
+
+#### One-time setup
+
+```
+# install pre-commit if you don’t already have it
+pip install pre-commit       # or brew install pre-commit / pipx install pre-commit
+
+# enable the git hook in this repo
+pre-commit install
+
+# optional: clean up the repo on demand
+pre-commit run --all-files
+git add -A
+```
+
+#### What happens on commit
+
+- Auto-fixers run (e.g. add final newlines).
+- After the auto-fixers, the editorconfig-checker runs inside Docker to validate all staged files.
+- If violations remain, fix them manually until the commit passes.

--- a/src/authentication/authenticationComponentTemplates/GenericAuthenticationMethodSelectionComponent.ts
+++ b/src/authentication/authenticationComponentTemplates/GenericAuthenticationMethodSelectionComponent.ts
@@ -79,4 +79,3 @@ export class GenericAuthenticationMethodSelectionComponent extends Authenticatio
 	}
 
 }
-


### PR DESCRIPTION
Use [pre-commit](https://pre-commit.com/) to enforce our `.editorconfig` locally. This ensures formatting issues are caught before code is committed, rather than only in CI.